### PR TITLE
Reverse specificity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,18 +26,18 @@ impl Metadata {
 
 impl Ord for Metadata {
     fn cmp(&self, other: &Metadata) -> Ordering {
-        if self.stars > other.stars {
-            Ordering::Less
-        } else if self.stars < other.stars {
+        if self.statics > other.statics {
             Ordering::Greater
-        } else if self.dynamics > other.dynamics {
-            Ordering::Less
-        } else if self.dynamics < other.dynamics {
-            Ordering::Greater
-        } else if self.statics > other.statics {
-            Ordering::Less
         } else if self.statics < other.statics {
+            Ordering::Less
+        } else if self.dynamics > other.dynamics {
             Ordering::Greater
+        } else if self.dynamics < other.dynamics {
+            Ordering::Less
+        } else if self.stars > other.stars {
+            Ordering::Greater
+        } else if self.stars < other.stars {
+            Ordering::Less
         } else {
             Ordering::Equal
         }
@@ -296,8 +296,8 @@ fn star() {
     assert_eq!(m.params, params("foo", "foo/bar"));
 
     let m = router.recognize("/bar/foo").unwrap();
-    assert_eq!(*m.handler, "test".to_string());
-    assert_eq!(m.params, params("foo", "bar/foo"));
+    assert_eq!(*m.handler, "test2".to_string());
+    assert_eq!(m.params, params("foo", "foo"));
 }
 
 #[bench]


### PR DESCRIPTION
The current ordering of routes causes lots of problems with wildcards/stars and should be reversed.
