### PR TITLE
fix nightly build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,6 +329,7 @@ fn star() {
     assert_eq!(m.params, params("foo", "bar/foo"));
 }
 
+#[cfg(test)]
 #[bench]
 fn benchmark(b: &mut test::Bencher) {
     let mut router = Router::new();

--- a/src/nfa.rs
+++ b/src/nfa.rs
@@ -565,6 +565,7 @@ fn test_ascii_set() {
     assert!(!set.contains('ü'), "The set does not contain ü");
 }
 
+#[cfg(test)]
 #[bench]
 fn bench_char_set(b: &mut test::Bencher) {
     let mut set = CharSet::new();
@@ -579,6 +580,7 @@ fn bench_char_set(b: &mut test::Bencher) {
     });
 }
 
+#[cfg(test)]
 #[bench]
 fn bench_hash_set(b: &mut test::Bencher) {
     let mut set = HashSet::new();
@@ -593,6 +595,7 @@ fn bench_hash_set(b: &mut test::Bencher) {
     });
 }
 
+#[cfg(test)]
 #[bench]
 fn bench_btree_set(b: &mut test::Bencher) {
     let mut set = BTreeSet::new();


### PR DESCRIPTION
This crate and crates that depend on it (e.g. iron -> docs.rs) have been unable to build on nightly since `nightly-2019-08-02` due to unstabilizing `#[bench]` - https://github.com/rust-lang/rust/pull/62507

```
error[E0658]: use of unstable library feature 'test': `bench` is a part of custom test frameworks which are unstable

#[bench]
  ^^^^^
 help: add `#![feature(test)]` to the crate attributes to enable
```