### PR TITLE
Enable feature to fix unstabilized `#[bench]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(test, feature(test))]
+#![feature(test)]
 
 #[cfg(test)] extern crate test;
 


### PR DESCRIPTION
rust-lang/rust#62507