### PR TITLE
Only add the parameters to the parameters map if they have a name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,9 @@ impl<T> Router<T> {
                 let param_names = metadata.param_names.clone();
 
                 for (i, capture) in nfa_match.captures.iter().enumerate() {
-                    map.insert(param_names[i].to_string(), capture.to_string());
+                    if !param_names[i].is_empty() {
+                        map.insert(param_names[i].to_string(), capture.to_string());
+                    }
                 }
 
                 let handler = self.handlers.get(&nfa_match.state).unwrap();
@@ -343,6 +345,21 @@ fn star() {
     let m = router.recognize("/bar/foo").unwrap();
     assert_eq!(*m.handler, "test".to_string());
     assert_eq!(m.params, params("foo", "bar/foo"));
+}
+
+#[test]
+fn unnamed_parameters() {
+    let mut router = Router::new();
+
+    router.add("/foo/:/bar", "test".to_string());
+    router.add("/foo/:bar/*", "test2".to_string());
+    let m = router.recognize("/foo/test/bar").unwrap();
+    assert_eq!(*m.handler, "test");
+    assert_eq!(m.params, Params::new());
+
+    let m = router.recognize("/foo/test/blah").unwrap();
+    assert_eq!(*m.handler, "test2");
+    assert_eq!(m.params, params("bar", "test"));
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
Closes #29 by only adding named parameters to the parameter map

## Description
If the capture has an empty string for a name then don't add it to the map

## Motivation and Context
Closes #29
Note this is technically a breaking change as before you could actually query for the parameter with an empty string.

## How Has This Been Tested?
Unit tests have been implemented to ensure the intended behaviour

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
