### PR TITLE
Extract the query string first before parsing the parameters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,17 +195,16 @@ impl<T> Router<T> {
             full_path = &full_path[1..];
         }
 
-        let (path, query_string) = match self.extract_query_string {
-            true => {
-                let mut segments = full_path.splitn(2, '?');
-                let path = segments.next().unwrap();
-                let query_string = match segments.next() {
-                    Some(s) => Some(s.to_string()),
-                    None => None,
-                };
-                (path, query_string)
-            }
-            false => (full_path, None),
+        let (path, query_string) = if self.extract_query_string {
+            let mut segments = full_path.splitn(2, '?');
+            let path = segments.next().unwrap();
+            let query_string = match segments.next() {
+                Some(s) => Some(s.to_string()),
+                None => None,
+            };
+            (path, query_string)
+        } else {
+            (full_path, None)
         };
 
         let nfa = &self.nfa;


### PR DESCRIPTION

## Description
Extract the query string from the URL before parsing it so that the value doesn't end up only in the last matching parameter.

Split the path at the first question mark before parsing the path and store the result in the query_string value of the match

Enable turning off the behaviour at the router level.

## Motivation and Context
Closes #30 
## How Has This Been Tested?
Unit tests are implemented to cover the use cases

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
